### PR TITLE
replace iteritems() with items()

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -17,7 +17,7 @@ Host {{ cfg.Host }}
     Hostname {{ cfg.Hostname }}
 {% endif -%}
 
-{% for key,value in cfg.iteritems() %}
+{% for key,value in cfg.items() %}
 {% if key == 'name' or key == 'Host' or key == 'Hostname' %}
 {# Already configured above so do nothing #}
 {% else %}


### PR DESCRIPTION
Python 3 uses `items()` instead of Python 2 `iteritems()`. Also see https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems